### PR TITLE
feat(deps): upgrade `@stackoverflow/stacks-icons` 3.0.4 -> 3.1.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 325 total icons
+> 327 total icons
 
 ## Icons
 
@@ -201,6 +201,8 @@
 - LogoWordmarkMd
 - LogoWordmarkSm
 - Mail
+- MailOpen
+- MailOpenSm
 - MailSm
 - Markdown
 - MarkdownPreview

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "svelte-check --workspace test"
   },
   "devDependencies": {
-    "@stackoverflow/stacks-icons": "3.0.4",
+    "@stackoverflow/stacks-icons": "3.1.0",
     "gh-pages": "^4.0.0",
     "rollup": "^2.79.0",
     "svelte": "^3.50.0",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { Alert, Calendar, Eye, Promoted, Placeholder, Discord } from "../lib";
+  import {
+    Alert,
+    Calendar,
+    Eye,
+    Promoted,
+    Placeholder,
+    Discord,
+    MailOpen,
+  } from "../lib";
   import Approve from "../lib/Approve.svelte";
 </script>
 
@@ -10,3 +18,4 @@
 <Promoted />
 <Placeholder />
 <Discord />
+<MailOpen />

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,10 +110,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@stackoverflow/stacks-icons@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@stackoverflow/stacks-icons/-/stacks-icons-3.0.4.tgz#abe40af62d89082e6c6d20c6a487f0aa5a1f1f30"
-  integrity sha512-96/XYk34tue58Ty7JnOvDAQbdiiNqnFVy/Etus5MfXshUYlLIHf0eupbRVf+FwLEuij7PuPbavUBRvlvTMhHsw==
+"@stackoverflow/stacks-icons@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@stackoverflow/stacks-icons/-/stacks-icons-3.1.0.tgz#9ed124ca86781ff4e3bda29ff673fd8a56a90f5c"
+  integrity sha512-RKdp9yb2dqCJuE0PWUPEBuB0X7w+iBlF1MZ2eiR/cWhyTUb1q17OKZWDR5jS6q53Cm8+80Q5ysDZu5tr96DwAA==
 
 "@types/estree@0.0.39":
   version "0.0.39"


### PR DESCRIPTION
- upgrade `@stackoverflow/stacks-icons` to version [3.1.0](https://github.com/StackExchange/Stacks-Icons/releases/tag/v3.1.0) (net +2 icons)